### PR TITLE
Don't trackRequest async in TrackRequest middleware

### DIFF
--- a/src/Middleware/TrackRequest.php
+++ b/src/Middleware/TrackRequest.php
@@ -21,6 +21,6 @@ class TrackRequest
 
 	public function terminate($request, $response)
 	{
-		app('insights')->trackRequest($request, $response, true);
+		app('insights')->trackRequest($request, $response);
 	}
 }


### PR DESCRIPTION
It turns out this results in nothing being logged, whoops!